### PR TITLE
Change API key, quick fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+

--- a/bilidan.py
+++ b/bilidan.py
@@ -53,8 +53,8 @@ import zlib
 
 USER_AGENT_PLAYER = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:6.0.2) Gecko/20100101 Firefox/6.0.2 Fengfan/1.0'
 USER_AGENT_API = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:6.0.2) Gecko/20100101 Firefox/6.0.2 Fengfan/1.0'
-APPKEY = '85eb6835b0a1034e'  # The same key as in original Biligrab
-APPSEC = '2ad42749773c441109bdc0191257a664'  # Do not abuse please, get one yourself if you need
+APPKEY = '452d3958f048c02a'  # From some source
+APPSEC = ''  # We shall not release this from now
 BILIGRAB_HEADER = {'User-Agent': USER_AGENT_API, 'Cache-Control': 'no-cache', 'Pragma': 'no-cache'}
 
 
@@ -88,7 +88,8 @@ def biligrab(url, *, debug=False, verbose=False, media=None, comment=None, cooki
         Return value: {'cid': cid, 'title': title}
         '''
         req_args = {'type': 'json', 'appkey': APPKEY, 'id': aid, 'page': pid}
-        req_args['sign'] = bilibili_hash(req_args)
+        #req_args['sign'] = bilibili_hash(req_args)
+        req_args['sign'] = ''
         _, response = fetch_url(url_get_metadata+urllib.parse.urlencode(req_args), user_agent=USER_AGENT_API, cookie=cookie)
         try:
             response = dict(json.loads(response.decode('utf-8', 'replace')))
@@ -112,7 +113,8 @@ def biligrab(url, *, debug=False, verbose=False, media=None, comment=None, cooki
             req_args = {'appkey': APPKEY, 'cid': cid}
             if quality is not None:
                 req_args['quality'] = quality
-            req_args['sign'] = bilibili_hash(req_args)
+            #req_args['sign'] = bilibili_hash(req_args)
+            req_args['sign'] = ''
             _, response = fetch_url(url_get_media+urllib.parse.urlencode(req_args), user_agent=user_agent, cookie=cookie, fakeip=fakeip)
             media_urls = [str(k.wholeText).strip() for i in xml.dom.minidom.parseString(response.decode('utf-8', 'replace')).getElementsByTagName('durl') for j in i.getElementsByTagName('url')[:1] for k in j.childNodes if k.nodeType == 4]
             if not fuck_you_bishi_mode and media_urls == ['http://static.hdslb.com/error.mp4']:


### PR DESCRIPTION
I just put a quick fix so everyone can use it for now.

Hoping this can give us some time to work around this issue.

```
$ ./bilidan.py http://www.bilibili.com/video/av899574/
-ERROR: Automatically downloading 'danmaku2ass.py'
       from https://github.com/m13253/danmaku2ass
       to /Users/Beining/Documents/coding/BiliDan/danmaku2ass.py
INFO: Loading video info...
INFO: Got video cid: 1445374
INFO: Loading video content...
INFO: Got media URLs:
      1: http://edge.v.iask.com/127734380.hlv?KID=sina,viask&Expires=1457884800&ssig=aj1xDQzV8C
      2: http://edge.v.iask.com/127734384.hlv?KID=sina,viask&Expires=1457884800&ssig=dtnMrZAavW
INFO: Determining video resolution...
^C
```