### PR TITLE
download danmaku2ass.py to the **real** BiliDan folder

### DIFF
--- a/bilidan.py
+++ b/bilidan.py
@@ -364,7 +364,7 @@ def check_env(debug=False):
     try:
         import danmaku2ass
     except ImportError as e:
-        danmaku2ass_filename = os.path.abspath(os.path.join(__file__, '..', 'danmaku2ass.py'))
+        danmaku2ass_filename = os.path.abspath(os.path.join(os.path.realpath(__file__), '..', 'danmaku2ass.py'))
         logging.error('Automatically downloading \'danmaku2ass.py\'\n       from https://github.com/m13253/danmaku2ass\n       to %s' % danmaku2ass_filename)
         try:
             danmaku2ass_downloaded = fetch_url('https://github.com/m13253/danmaku2ass/raw/master/danmaku2ass.py')


### PR DESCRIPTION
When using a symbol link to run the bilidan.py script, the required danmaku2ass.py file will be downloaded to the BiliDan folder, instead of the folder where the symbol link is.

(For me, I alway use a symbol link in the $PATH to run scripts from Github, and keep those scripts in their own directories)