### PR TITLE
fix function call incompatibility on Danmaku2ASS, due to API change.

### DIFF
--- a/bilidan.py
+++ b/bilidan.py
@@ -216,7 +216,7 @@ def biligrab(url, *, debug=False, verbose=False, media=None, comment=None, cooki
                 if k in d2aflags:
                     d2a_args[k] = j(d2aflags[k])
         try:
-            danmaku2ass.Danmaku2ASS(input_files=[comment_in], output_file=comment_out, **d2a_args)
+            danmaku2ass.Danmaku2ASS(input_files=[comment_in], input_format='Bilibili', output_file=comment_out, **d2a_args)
         except Exception as e:
             log_or_raise(e, debug=debug)
             logging.error('Danmaku2ASS failed, comments are disabled.')


### PR DESCRIPTION
After the argument 'input_format' was added to Danmaku2ASS. the function call in bilidan became incompatible and get error log "ERROR: Danmaku2ASS() missing 1 required positional argument: 'input_format'
ERROR: Danmaku2ASS failed, comments are disabled." when running.
After adding the positional argument, the problem get fixed. The value of the parameter could even be 'Bilibili' to avoid unnecessary auto detection, since bilidan is designed for Bilibili.